### PR TITLE
Fixing Issue #2(https://github.com/schubergphilis/sbp_packer/issues/2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This will put Packer into `/usr/local` in a `packer-*version*` directory, with a
 # Attributes
 
 * `node['packer']['url_base']` - Base URL from which to download (in case you have your own mirror). Defaults to the link at http://www.packer.io/downloads.html.
+* `node['packer']['zipfile']` - On binary installations, this is the name of the packer zip file with no path info
 * `node['packer']['version']` - The version of Packer to install.
 * `node['packer']['arch']` - Architecture to use; auto-detects amd64 and 386 but you must override with arm if desired.
 * `node['packer']['raw_checksums']` - The contents of the upstream checksum file to allow checksum auto-detection.

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ This will put Packer into `/usr/local` in a `packer-*version*` directory, with a
 
 # Attributes
 
-* `node[:packer][:url_base]` - Base URL from which to download (in case you have your own mirror). Defaults to the link at http://www.packer.io/downloads.html.
-* `node[:packer][:version]` - The version of Packer to install.
-* `node[:packer][:arch]` - Architecture to use; auto-detects amd64 and 386 but you must override with arm if desired.
-* `node[:packer][:raw_checksums]` - The contents of the upstream checksum file to allow checksum auto-detection.
-* `node[:packer][:checksums]` - A `Hash` mapping file name to checksums, derived by default from `raw_checksums`.
-* `node[:packer][:checksum]` - SHA-256 checksum of appropriate binary. Should be auto-detected for the default version using data in `raw_checksums` or `checksums`.
-* `node[:packer][:install_method]` - Either 'binary' or 'source'
+* `node['packer']['url_base']` - Base URL from which to download (in case you have your own mirror). Defaults to the link at http://www.packer.io/downloads.html.
+* `node['packer']['version']` - The version of Packer to install.
+* `node['packer']['arch']` - Architecture to use; auto-detects amd64 and 386 but you must override with arm if desired.
+* `node['packer']['raw_checksums']` - The contents of the upstream checksum file to allow checksum auto-detection.
+* `node['packer']['checksums']` - A `Hash` mapping file name to checksums, derived by default from `raw_checksums`.
+* `node['packer']['checksum']` - SHA-256 checksum of appropriate binary. Should be auto-detected for the default version using data in `raw_checksums` or `checksums`.
+* `node['packer']['install_method']` - Either 'binary' or 'source'
 
 When overriding with a particular desired version, you can set the checksum a variety of ways. When
 this cookbook is updated for a new default version, the checksums will be updated by the maintainers.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,7 @@
 default['packer']['url_base'] = 'https://dl.bintray.com/mitchellh/packer'
 default['packer']['version'] = '0.8.6'
 default['packer']['arch'] = kernel['machine'] =~ /x86_64/ ? 'amd64' : '386'
+default['packer']['zipfile'] = ''
 
 # rubocop:disable Metrics/LineLength
 # Transform raw output of the bintray checksum list into a Hash[filename, checksum].

--- a/chefignore
+++ b/chefignore
@@ -94,3 +94,9 @@ Vagrantfile
 # Travis #
 ##########
 .travis.yml
+
+# Test Kitchen #
+################
+.kitchen/*
+.kitchen.yml
+

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'arepton@schubergphilis.com'
 license 'Apache 2.0'
 description 'Installs/Configures packer'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.2'
+version '1.1.0'
 
 depends 'ark', '~> 0.9.0'
 depends 'golang', '~> 1.5.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'arepton@schubergphilis.com'
 license 'Apache 2.0'
 description 'Installs/Configures packer'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.1'
+version '1.0.2'
 
 depends 'ark', '~> 0.9.0'
 depends 'golang', '~> 1.5.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,12 +12,9 @@
 # limitations under the License.
 #
 
-case node['packer']['install_method']
-when 'binary'
-  include_recipe 'sbp_packer::install_binary'
-when 'source'
-  include_recipe 'sbp_packer::install_source'
-else
-  # rubocop:disable Metrics/LineLength
-  Chef::Application.fatal!("[packer::default] unknown install method, method=#{node['consul']['install_method']}")
+unless %w(binary source).include? node['packer']['install_method']
+  Chef::Application.fatal!('[packer::default] unknown install method, ' \
+    "method=#{node['consul']['install_method']}")
 end
+
+include_recipe "sbp_packer::#{node['packer']['install_method']}"

--- a/recipes/install_binary.rb
+++ b/recipes/install_binary.rb
@@ -8,9 +8,11 @@
 
 include_recipe 'ark'
 
+node.default['packer']['zipfile'] = "packer_#{node['packer']['version']}_" \
+  "#{node['os']}_#{node['packer']['arch']}.zip"
+
 ark 'packer' do
-  # rubocop:disable Metrics/LineLength
-  url "#{node['packer']['url_base']}/packer_#{node['packer']['version']}_#{node['os']}_#{node['packer']['arch']}.zip"
+  url "#{node['packer']['url_base']}/#{node['packer']['zipfile']}"
   version node['packer']['version']
   checksum node['packer']['checksum']
   has_binaries ['packer']
@@ -27,7 +29,7 @@ end
 
 # update path
 if platform_family?('windows')
-   windows_path node['packer']['win_install_dir'] do
-     action :add
-   end
+  windows_path node['packer']['win_install_dir'] do
+    action :add
+  end
 end


### PR DESCRIPTION
added a node attribute, `node['packer']['zipfile']` to allow for flexible naming of the packer zip file used during binary installs
