### PR TITLE
add test coverage, packer 0.9.0 update, minor improvements

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,7 +3,7 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_solo
+  name: chef_zero
 
 platforms:
   - name: ubuntu-12.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,12 +15,14 @@ suites:
   - name: binary_install
     run_list:
       - recipe[minitest-handler]
+      - recipe[sbp_packer_test]
       - recipe[sbp_packer::default]
     attributes:
 
   - name: source_install
     run_list:
       - recipe[minitest-handler]
+      - recipe[sbp_packer_test]
       - recipe[sbp_packer::default]
     attributes:
       packer:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,11 +14,13 @@ platforms:
 suites:
   - name: binary_install
     run_list:
+      - recipe[minitest-handler]
       - recipe[sbp_packer::default]
     attributes:
 
   - name: source_install
     run_list:
+      - recipe[minitest-handler]
       - recipe[sbp_packer::default]
     attributes:
       packer:

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,4 @@
 source 'https://supermarket.chef.io'
 
 metadata
+cookbook 'minitest-handler', '~> 1.5.0'

--- a/Berksfile
+++ b/Berksfile
@@ -2,3 +2,4 @@ source 'https://supermarket.chef.io'
 
 metadata
 cookbook 'minitest-handler', '~> 1.5.0'
+cookbook 'sbp_packer_test', path: 'test/cookbooks/sbp_packer_test'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+This is a changelog for the sbp_packer cookbook.
+
+## 1.2.0
+  * Starting the change log here, since none existed before
+  * Updated for packer 0.9.0
+  * added minitest-handler dependency for run-time assertions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This is a changelog for the sbp_packer cookbook.
   * Starting the change log here, since none existed before
   * Updated for packer 0.9.0
   * added minitest-handler dependency for run-time assertions
+  * Added node['packer']['source_repo_url'] to contain the URL for the packer repo during a source install
 
 
 ------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,8 @@ This is a changelog for the sbp_packer cookbook.
   * Starting the change log here, since none existed before
   * Updated for packer 0.9.0
   * added minitest-handler dependency for run-time assertions
+
+
+------------------------------------
+maintainer Andrew Repton <arepton@schubergphilis.com>
+contributor Dang H. nguyen <haidangwa@gmail.com>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
-default['packer']['url_base'] = 'https://releases.hashicorp.com/packer/' \
-  "#{node['packer']['version']}/"
 default['packer']['version'] = '0.9.0'
+default['packer']['url_base'] = 'https://releases.hashicorp.com/packer/' \
+  "#{node['packer']['version']}"
 default['packer']['arch'] = kernel['machine'] =~ /x86_64/ ? 'amd64' : '386'
 default['packer']['zipfile'] = "packer_#{node['packer']['version']}_" \
   "#{node['os']}_#{node['packer']['arch']}.zip"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
-default['packer']['url_base'] = 'https://releases.hashicorp.com/packer'
+default['packer']['url_base'] = 'https://releases.hashicorp.com/packer/' \
+  "#{node['packer']['version']}/"
 default['packer']['version'] = '0.9.0'
 default['packer']['arch'] = kernel['machine'] =~ /x86_64/ ? 'amd64' : '386'
 default['packer']['zipfile'] = "packer_#{node['packer']['version']}_" \

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,7 +33,6 @@ default['packer']['checksum'] = node['packer']['checksums'][filename]
 
 default['packer']['install_method'] = 'binary'
 default['packer']['install_dir'] = '/usr/local/bin'
-default['packer']['source_revision'] = 'master'
 
 # Windows attribute
 if platform_family?('windows')

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 default['packer']['url_base'] = 'https://releases.hashicorp.com/packer'
-default['packer']['version'] = '0.8.6'
+default['packer']['version'] = '0.9.0'
 default['packer']['arch'] = kernel['machine'] =~ /x86_64/ ? 'amd64' : '386'
 default['packer']['zipfile'] = "packer_#{node['packer']['version']}_" \
   "#{node['os']}_#{node['packer']['arch']}.zip"
@@ -8,18 +8,18 @@ default['packer']['zipfile'] = "packer_#{node['packer']['version']}_" \
 # Transform raw output of the checksum list into a Hash[filename, checksum].
 # https://releases.hashicorp.com/packer/${VERSION}/packer_${VERSION}_SHA256SUMS
 default['packer']['raw_checksums'] = <<-EOF
-1fb3b1382885f39c1f1f159fc7a6ef4be12d074c97fba76e0050d1990a990aed  packer_0.8.6_darwin_386.zip
-91b5e5d4524a7a2f09a07aad1c8e26e1200b47191a42c1b2facac4a27fd674d0  packer_0.8.6_darwin_amd64.zip
-c1eee9159a2b808a98392026b18b9b8d273dc7315729be223b872f244ee4a8a2  packer_0.8.6_freebsd_386.zip
-bd0dac59e22a490068f45e4d97a8e698637efca88c89caa7df764ea96bd7b718  packer_0.8.6_freebsd_amd64.zip
-4ca3827f70af25656dd3eff6ac442b0e62adc28d6ea1d56f47721189bb7d0453  packer_0.8.6_freebsd_arm.zip
-d1385af26ea42560ddc4f4958c88cb00c3e4a9f8a2d88a81c96b4bf1cb60369b  packer_0.8.6_linux_386.zip
-2f1ca794e51de831ace30792ab0886aca516bf6b407f6027e816ba7ca79703b5  packer_0.8.6_linux_amd64.zip
-958cbae3f99990946c1de9af238bf1760c3382f83c4975a32be54cfb0378d8d8  packer_0.8.6_linux_arm.zip
-009f30cf9f137429ca4dc2c175e0431a72f44ba3dd427cb8a173c68c7d3be7eb  packer_0.8.6_openbsd_386.zip
-bfab2f16a6b4f34e317d792ad97c3e879304dc8ae7866e70737f61ebfc8952a0  packer_0.8.6_openbsd_amd64.zip
-8d0bd037909206926d988b30e9336faf105dffe97c2924d455b28de437557c7f  packer_0.8.6_windows_386.zip
-786503f2ffe658c1b318af227eabb8c10f3f425608ad4ef709206757931b7eee  packer_0.8.6_windows_amd64.zip
+ce1400cdd612f340ad500b68d83f6615996f510344b1fe57cc01ac3a87b47954  packer_0.9.0_darwin_386.zip
+bd5f8ce38ceb866c3f1db2eb3d51091184dd021dd785d05bb47177b223fea9df  packer_0.9.0_darwin_amd64.zip
+3ec41f6fe29fe2e6d4182441f4d07f67124562e2cae27c2ee51600c42432ea0b  packer_0.9.0_freebsd_386.zip
+5355cdd8e6d7b5fdaa416e466bf782c46130cdf96087dca621bc16d3fd5a2d3b  packer_0.9.0_freebsd_amd64.zip
+618e99c2b92a1f6f79a92b6602fcf248fa3ac1aceb76119b250055f5f618141e  packer_0.9.0_freebsd_arm.zip
+f3b3dea98f7b7e852d4919074d7a3878f7cc7072338f18e3e5c5e55628b43bf1  packer_0.9.0_linux_386.zip
+4119d711855e8b85edb37f2299311f08c215fca884d3e941433f85081387e17c  packer_0.9.0_linux_amd64.zip
+30d5a7cee03d3f838c49136a58ed935023093ebaecf063b9f47799e5e5d52c09  packer_0.9.0_linux_arm.zip
+b0c498c2265a952d417fe971351f5837edd0bafc9727c4cb2582b808468cced0  packer_0.9.0_openbsd_386.zip
+81266445a954f166e1da01f1d2f99962cf7f58a304f809900e646b58550ccf11  packer_0.9.0_openbsd_amd64.zip
+f3ea971cefc60e953d64b944fee71b4eb77606895f690a51f485c2562e36f2e9  packer_0.9.0_windows_386.zip
+dbb98c5a3be92bfe5a4bca5f29d5a9159409af0f360d590953b0e806ebe2342a  packer_0.9.0_windows_amd64.zip
 EOF
 
 node.default['packer']['checksums'] = Hash[

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,8 @@
 default['packer']['url_base'] = 'https://releases.hashicorp.com/packer'
 default['packer']['version'] = '0.8.6'
 default['packer']['arch'] = kernel['machine'] =~ /x86_64/ ? 'amd64' : '386'
-default['packer']['zipfile'] = ''
+default['packer']['zipfile'] = "packer_#{node['packer']['version']}_" \
+  "#{node['os']}_#{node['packer']['arch']}.zip"
 
 # rubocop:disable Metrics/LineLength
 # Transform raw output of the checksum list into a Hash[filename, checksum].

--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -1,2 +1,3 @@
 default['packer']['source_revision'] = 'master'
 default['packer']['source_repo_url'] = 'https://github.com/mitchellh/packer.git'
+default['packer']['source_install_path'] = "#{node['go']['gopath']}/src/github.com/mitchellh/packer"

--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -1,0 +1,2 @@
+default['packer']['source_revision'] = 'master'
+default['packer']['source_repo_url'] = 'https://github.com/mitchellh/packer.git'

--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -1,3 +1,4 @@
 default['packer']['source_revision'] = 'master'
 default['packer']['source_repo_url'] = 'https://github.com/mitchellh/packer.git'
-default['packer']['source_install_path'] = "#{node['go']['gopath']}/src/github.com/mitchellh/packer"
+default['packer']['source_install_path'] = "#{node['go']['gopath']}/src/" \
+  'github.com/mitchellh/packer'

--- a/files/default/tests/minitest/install_binary_test.rb
+++ b/files/default/tests/minitest/install_binary_test.rb
@@ -3,21 +3,24 @@ require_relative 'support/test_helper'
 describe_recipe 'sbp_packer::install_binary' do
   include ChefPacker::TestHelper
 
+  before(:each) do
+    @packer_dir = "/usr/local/packer-#{node['packer']['version']}"
+  end
+
   it 'installed packer' do
     skip 'not tested under Windows' if node['platform_family'] == 'windows'
-    packer_dir = "/usr/local/packer-#{node['sbp_packer']['version']}"
-    directory(packer_dir)
+    directory(@packer_dir)
       .must_exist
       .with(:mode, '755')
       .and(:owner, 'root')
       .and(:group, 'root')
     link('/usr/local/packer')
       .must_exist
-      .with(:to, packer_dir)
+      .with(:to, @packer_dir)
     link('/usr/local/bin/packer')
       .must_exist
-      .with(:to, File.join(packer_dir, 'packer'))
-    file(File.join(packer_dir, 'packer'))
+      .with(:to, File.join(@packer_dir, 'packer'))
+    file(File.join(@packer_dir, 'packer'))
       .must_exist
       .with(:mode, '755')
   end

--- a/files/default/tests/minitest/install_binary_test.rb
+++ b/files/default/tests/minitest/install_binary_test.rb
@@ -1,0 +1,24 @@
+require_relative 'support/test_helper'
+
+describe_recipe 'sbp_packer::install_binary' do
+  include ChefPacker::TestHelper
+
+  it 'installed packer' do
+    skip 'not tested under Windows' if node['platform_family'] == 'windows'
+    packer_dir = "/usr/local/packer-#{node['sbp_packer']['version']}"
+    directory(packer_dir)
+      .must_exist
+      .with(:mode, '755')
+      .and(:owner, 'root')
+      .and(:group, 'root')
+    link('/usr/local/packer')
+      .must_exist
+      .with(:to, packer_dir)
+    link('/usr/local/bin/packer')
+      .must_exist
+      .with(:to, File.join(packer_dir, 'packer'))
+    file(File.join(packer_dir, 'packer'))
+      .must_exist
+      .with(:mode, '755')
+  end
+end

--- a/files/default/tests/minitest/install_source_test.rb
+++ b/files/default/tests/minitest/install_source_test.rb
@@ -6,7 +6,7 @@ describe_recipe 'sbp_packer::install_source' do
   it 'created source dir' do
     skip 'not tested under Windows' if node['platform_family'] == 'windows'
     require 'uri'
-    
+
     uri = URI.parse(node['packer']['source_repo_url'])
     src_dir = "#{node['go']['gopath']}/src/#{uri}".gsub('.git', '')
     directory(src_dir)

--- a/files/default/tests/minitest/install_source_test.rb
+++ b/files/default/tests/minitest/install_source_test.rb
@@ -5,7 +5,10 @@ describe_recipe 'sbp_packer::install_source' do
 
   it 'created source dir' do
     skip 'not tested under Windows' if node['platform_family'] == 'windows'
-    src_dir = "#{node['go']['gopath']}/src/github.com/hashicorp"
+    require 'uri'
+    
+    uri = URI.parse(node['packer']['source_repo_url'])
+    src_dir = "#{node['go']['gopath']}/src/#{uri}".gsub('.git', '')
     directory(src_dir)
       .must_exist
       .with(:mode, '755')

--- a/files/default/tests/minitest/install_source_test.rb
+++ b/files/default/tests/minitest/install_source_test.rb
@@ -1,0 +1,22 @@
+require_relative 'support/test_helper'
+
+describe_recipe 'sbp_packer::install_source' do
+  include ChefPacker::TestHelper
+
+  it 'created source dir' do
+    skip 'not tested under Windows' if node['platform_family'] == 'windows'
+    src_dir = "#{node['go']['gopath']}/src/github.com/hashicorp"
+    directory(src_dir)
+      .must_exist
+      .with(:mode, '755')
+      .and(:owner, 'root')
+      .and(:group, 'root')
+  end
+
+  it 'symlink executable' do
+    directory('/usr/local/bin').must_exist
+    link('/usr/local/bin/packer')
+      .must_exist
+      .with(:to, "#{src_dir}/packer")
+  end
+end

--- a/files/default/tests/minitest/support/test_helper.rb
+++ b/files/default/tests/minitest/support/test_helper.rb
@@ -1,0 +1,18 @@
+
+# **NOTE** This file should be required from *inside* of a describe_recipe
+# block. Doing it globally at the top of a test file has been seen to cause
+# issues
+require 'minitest/spec'
+require 'minitest-chef-handler'
+
+# this module starts ChefPacker
+module ChefPacker
+  # test helper module under sbp_packer
+  module TestHelper
+    # This module is intended to be included form test cases to help reduce
+    # duplication of includes
+    include MiniTest::Chef::Assertions
+    include MiniTest::Chef::Context
+    include MiniTest::Chef::Resources
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,3 +8,8 @@ version '1.2.0'
 
 depends 'ark', '~> 1.0.0'
 depends 'golang', '~> 1.7.0'
+
+supports 'ubuntu', '= 12.04'
+supports 'ubuntu', '= 14.04'
+supports 'centos', '= 6.5'
+supports 'centos', '= 7.1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'arepton@schubergphilis.com'
 license 'Apache 2.0'
 description 'Installs/Configures packer'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.2'
+version '1.2.0'
 
-depends 'ark', '~> 0.9.0'
-depends 'golang', '~> 1.5.0'
+depends 'ark', '~> 1.0.0'
+depends 'golang', '~> 1.7.0'

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -15,6 +15,7 @@
 require 'uri'
 
 uri = URI.parse(node['packer']['source_repo_url'])
+golang_install_dir = "#{uri.host}#{uri.path}".gsub('.git', '')
 
 include_recipe 'golang::default'
 
@@ -26,13 +27,17 @@ directory File.join(node['go']['gopath'], 'src/github.com/hashicorp') do
   action :create
 end
 
+directory ::File.dirname(node['packer']['source_install_path']) do
+  recursive true
+end
+
 git node['packer']['source_install_path'] do
   repository node['packer']['source_repo_url']
   reference node['packer']['source_revision']
   action :checkout
 end
 
-golang_package "#{uri.host}#{uri.path}".gsub('.git', '') do
+golang_package golang_install_dir do
   action :install
 end
 

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -23,7 +23,7 @@ directory File.join(node['go']['gopath'], 'src/github.com/hashicorp') do
 end
 
 git File.join(node['go']['gopath'], '/src/github.com/hashicorp/packer') do
-  repository 'http://github.com/hashicorp/packer.git'
+  repository node['packer']['source_repo_url']
   reference node['packer']['source_revision']
   action :checkout
 end

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -12,6 +12,10 @@
 # limitations under the License.
 #
 
+require 'uri'
+
+uri = URI.parse(node['packer']['source_repo_url'])
+
 include_recipe 'golang::default'
 
 directory File.join(node['go']['gopath'], 'src/github.com/hashicorp') do
@@ -22,13 +26,13 @@ directory File.join(node['go']['gopath'], 'src/github.com/hashicorp') do
   action :create
 end
 
-git File.join(node['go']['gopath'], '/src/github.com/hashicorp/packer') do
+git node['packer']['source_install_path'] do
   repository node['packer']['source_repo_url']
   reference node['packer']['source_revision']
   action :checkout
 end
 
-golang_package 'github.com/hashicorp/packer' do
+golang_package "#{uri.host}#{uri.path}".gsub('.git', '') do
   action :install
 end
 
@@ -38,5 +42,5 @@ directory '/usr/local/bin' do
 end
 
 link '/usr/local/bin/packer' do
-  to File.join(node['go']['gopath'], '/src/github.com/hashicorp/packer')
+  to node['packer']['source_install_path']
 end

--- a/test/cookbooks/sbp_packer_test/metadata.rb
+++ b/test/cookbooks/sbp_packer_test/metadata.rb
@@ -1,0 +1,2 @@
+name 'sbp_packer_test'
+version '0.1.0'

--- a/test/cookbooks/sbp_packer_test/recipes/default.rb
+++ b/test/cookbooks/sbp_packer_test/recipes/default.rb
@@ -1,0 +1,1 @@
+execute 'apt-get update'

--- a/test/cookbooks/sbp_packer_test/recipes/default.rb
+++ b/test/cookbooks/sbp_packer_test/recipes/default.rb
@@ -1,1 +1,1 @@
-execute 'apt-get update'
+execute 'apt-get update' if node['platform_family'] == 'debian'


### PR DESCRIPTION
- Starting the change log here, since none existed before
- Updated for packer 0.9.0
- added minitest-handler dependency for run-time assertions
- Added node['packer']['source_repo_url'] to contain the URL for the packer repo during a source install
- all tests for the binary installation pass Test Kitchen - source installation still needs work
