### PR TITLE
Fix incorrectly generated download URL

### DIFF
--- a/recipes/install_binary.rb
+++ b/recipes/install_binary.rb
@@ -8,10 +8,6 @@
 
 include_recipe 'ark'
 
-node.default['packer']['zipfile'] = "#{node['packer']['version']}/" \
-  "packer_#{node['packer']['version']}_" \
-  "#{node['os']}_#{node['packer']['arch']}.zip"
-
 ark 'packer' do
   url "#{node['packer']['url_base']}/#{node['packer']['zipfile']}"
   version node['packer']['version']


### PR DESCRIPTION
Fixes #9 

Tested branch locally with test-kitchen and Packer 0.9.0 installed successfully.

```
       Recipe: sbp_packer::install_binary



           * remote_file[/tmp/kitchen/cache/packer-0.9.0.zip] action create



           * execute[unpack /tmp/kitchen/cache/packer-0.9.0.zip] action nothing (skipped due to action :nothing)
           * execute[set owner on /usr/local/packer-0.9.0] action nothing (skipped due to action :nothing)
           * link[/usr/local/bin/packer] action create
             - create symlink at /usr/local/bin/packer to /usr/local/packer-0.9.0/packer
           * link[/usr/local/packer] action create
       - create symlink at /usr/local/packer to /usr/local/packer-0.9.0
           * template[/etc/profile.d/packer.sh] action create (skipped due to only_if)
           * ruby_block[adding '/usr/local/packer-0.9.0/bin' to chef-client ENV['PATH']] action run (skipped due to only_if)
           * execute[unpack /tmp/kitchen/cache/packer-0.9.0.zip] action run

           * execute[set owner on /usr/local/packer-0.9.0] action run
             - execute chown -R root:0 /usr/local/packer-0.9.0
```
