### PR TITLE
unlocking dependancies for arc and golang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 This is a changelog for the sbp_packer cookbook.
 
+## 1.4.3
+  * Unlock metadata.rb depends for ark and golang.
+
 ## 1.4.2
   * Update to Packer 0.12.2
   * Update test kitchen centos-6.6 to centos-6.8
@@ -20,3 +23,4 @@ This is a changelog for the sbp_packer cookbook.
 Maintainer Andrew Repton <arepton@schubergphilis.com>
 Contributor Dang H. nguyen <haidangwa@gmail.com>
 Contributor Micheal Waltz <ecliptik@gmail.com>
+Contributor Dayne Broderson <broderson@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,4 +23,3 @@ This is a changelog for the sbp_packer cookbook.
 Maintainer Andrew Repton <arepton@schubergphilis.com>
 Contributor Dang H. nguyen <haidangwa@gmail.com>
 Contributor Micheal Waltz <ecliptik@gmail.com>
-Contributor Dayne Broderson <broderson@gmail.com>

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,10 +4,10 @@ maintainer_email 'arepton@schubergphilis.com'
 license 'Apache 2.0'
 description 'Installs/Configures packer'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.4.3'
+version '1.4.4'
 
-depends 'ark', '~> 1.0.0'
-depends 'golang', '~> 1.7.0'
+depends 'ark'
+depends 'golang'
 
 supports 'ubuntu', '= 12.04'
 supports 'ubuntu', '= 14.04'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,8 @@ description 'Installs/Configures packer'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.4.4'
 
-depends 'ark'
+depends 'ark', '> 1.0.0'
+depends 'golan', '> 1.7.0'
 depends 'golang'
 
 supports 'ubuntu', '= 12.04'


### PR DESCRIPTION
This pull request is a request to unlock the depends here and let people manage the specific arc's in their policy or other areas.

After last months basic *sbp_packer* testing/updating I rolled back around to integrating *sbp_packer* into a more complex cookbook I've developed for my dev boxes.  Ran into some pretty horrible explosions from `berks` doing resolves. Berks was crashing or having weird unable to resolve issues.  After banging around a bit I narrowed the issue down to be one of my other recipes was using a newer version of arc (2.0) and *sbp_packer*'s metadata.rb has `depends 'arc', '~> 1.0.0'` 

After changing that to `depends 'arc', '> 1.0.0'` things worked fine. I have been trying to minimize strict version pinning for lower level cookbooks and do version pinning at a different level (environments, policyfiles).

Recommend we remove the version pinning for *sbp_packer* dependencies on *ark* and *golang*

