### PR TITLE
chef13 wants you to access through node['kernel']['machine'] now

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 default['packer']['version'] = '1.0.0'
 default['packer']['url_base'] = 'https://releases.hashicorp.com/packer/' \
   "#{node['packer']['version']}"
-default['packer']['arch'] = kernel['machine'] =~ /x86_64/ ? 'amd64' : '386'
+default['packer']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? 'amd64' : '386'
 default['packer']['zipfile'] = "packer_#{node['packer']['version']}_" \
   "#{node['os']}_#{node['packer']['arch']}.zip"
 


### PR DESCRIPTION
Noticed a deprecation message when doing some testing earlier.  Decided to debug it and found this is a simple fix. 

https://docs.chef.io/deprecations_chef_platform_methods.html

_However_

The real trick is the tests for sbp_packer will also need to be address to be ready for chef13. Need to convert tests from minitest-handler to inspec. 

I've got a start on the inspec test pivot that I will include as a separate pull request. 
